### PR TITLE
feat(baseline): BL-0 carry-forward + unit test + minimal CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,7 @@ ingest-gdp-latest:
 .PHONY: ingest-registry
 ingest-registry:
 	python -m nowcast_gdp.ingest_alfred --from-registry --active-only --registry config/series.toml
+
+# --- Baselines: BL-0 quick print
+bl0-print:
+	python -m nowcast_gdp.baselines --series $(SERIES) --model bl0 --h $(H) --print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.12"
 authors = [{ name = "rkendev" }]
 # Optional but recommended:
 # license = { file = "LICENSE" }
-dependencies = ["requests>=2.31"]  # add runtime deps later
+dependencies = [ "requests>=2.31",
+                 "pandas",]  # add runtime deps later
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]

--- a/src/nowcast_gdp/baselines/__init__.py
+++ b/src/nowcast_gdp/baselines/__init__.py
@@ -1,0 +1,4 @@
+# src/nowcast_gdp/baselines/__init__.py
+from .bl0 import forecast_last
+
+__all__ = ["forecast_last"]

--- a/src/nowcast_gdp/baselines/__main__.py
+++ b/src/nowcast_gdp/baselines/__main__.py
@@ -1,0 +1,45 @@
+# src/nowcast_gdp/baselines/__main__.py
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import List
+
+from nowcast_gdp.dataio import read_latest_series
+
+from .bl0 import forecast_last
+
+
+def main(argv: List[str] | None = None) -> int:
+    ap = ArgumentParser(description="Run simple baselines over latest series")
+    ap.add_argument("--series", required=True, help="Series ID, e.g. GDP")
+    ap.add_argument("--model", default="bl0", choices=["bl0"], help="Baseline model")
+    ap.add_argument("--h", type=int, default=1, help="Forecast horizon (steps)")
+    ap.add_argument(
+        "--base",
+        default=str(Path("data") / "raw" / "alfred"),
+        help="Root for raw ALFRED data (default: data/raw/alfred)",
+    )
+    ap.add_argument("--print", action="store_true", help="Print forecasts to stdout")
+    args = ap.parse_args(argv)
+
+    # load latest vintage series
+    _dates, values = read_latest_series(args.series, base=Path(args.base))
+    if not values:
+        raise SystemExit(f"No values found for series {args.series} under {args.base}")
+
+    # select model
+    if args.model == "bl0":
+        yhat = forecast_last(values, h=args.h)
+    else:
+        raise SystemExit(f"Unknown model: {args.model}")
+
+    if args.print:
+        for i, val in enumerate(yhat, start=1):
+            print(f"h={i}, forecast={val}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nowcast_gdp/baselines/bl0.py
+++ b/src/nowcast_gdp/baselines/bl0.py
@@ -1,0 +1,18 @@
+# src/nowcast_gdp/baselines/bl0.py
+from __future__ import annotations
+
+from typing import List, Sequence
+
+
+def forecast_last(y: Sequence[float], h: int = 1) -> List[float]:
+    """
+    BL-0 carry-forward baseline:
+    Return an h-step forecast where every horizon equals the last observed value.
+    Raises ValueError if y is empty or h < 1.
+    """
+    if h < 1:
+        raise ValueError("h must be >= 1")
+    if not y:
+        raise ValueError("y must be non-empty")
+    last = y[-1]
+    return [float(last)] * h

--- a/src/nowcast_gdp/dataio.py
+++ b/src/nowcast_gdp/dataio.py
@@ -91,3 +91,24 @@ def read_latest_series(series_id: str, base: Path | None = None) -> Tuple[List[d
             # Robust to occasional bad rows
             continue
     return dts, vals
+
+
+# ---------- aliases & niceties ----------
+# alias for discoverability (so your earlier import works)
+read_latest_vintage = latest_vintage
+
+
+def read_latest_series_df(series_id: str, base: Path | None = None):
+    """Return latest series as a pandas DataFrame with Date index."""
+    import pandas as pd
+
+    dts, vals = read_latest_series(series_id, base)
+    return pd.DataFrame({"date": dts, "value": vals}).set_index("date")
+
+
+__all__ = [
+    "latest_vintage",
+    "read_latest_vintage",
+    "read_latest_series",
+    "read_latest_series_df",
+]

--- a/tests/test_baseline_bl0.py
+++ b/tests/test_baseline_bl0.py
@@ -1,0 +1,19 @@
+# tests/test_baseline_bl0.py
+from __future__ import annotations
+
+import pytest
+
+from nowcast_gdp.baselines.bl0 import forecast_last
+
+
+def test_bl0_basic():
+    y = [1.0, 2.0, 3.5]
+    assert forecast_last(y, h=1) == [3.5]
+    assert forecast_last(y, h=3) == [3.5, 3.5, 3.5]
+
+
+def test_bl0_validations():
+    with pytest.raises(ValueError):
+        forecast_last([], h=1)
+    with pytest.raises(ValueError):
+        forecast_last([1.0], h=0)


### PR DESCRIPTION
## Summary
Add a tiny BL-0 (carry-forward) baseline and a minimal CLI to exercise it on the latest vintage.

## Changes
- [x] Core code: baselines/bl0.py with `forecast_last(y, h)`
- [x] CLI: `python -m nowcast_gdp.baselines --series GDP --model bl0 --h 4 --print`
- [x] Tests: unit tests for forecast/validation
- [ ] Docs: a short README snippet can be added in the next PR

## Tests & Evidence
- Unit: `tests/test_baseline_bl0.py` passes locally
- Integration: `make bl0-print SERIES=GDP H=4` prints 4 identical values (latest level)
- CI runtime: negligible

## Risk & Rollback
- Low; isolated new module and test
- Rollback: revert this commit

## Checklist
- [x] Lint/format OK
- [x] Tests added, `pytest -q` green
- [x] No secrets/PII committed
